### PR TITLE
Fix default value for --expiration option in the README documentation

### DIFF
--- a/README
+++ b/README
@@ -116,7 +116,7 @@ By default, a key/data pair can be up to 32 Mb large. This is a huge default.
 Start the server with that value and reduce it later according to the largest
 files you get in the work directory.
 
-Without the --expiration switch, a key/data pair expires after 60 minutes of
+Without the --expiration switch, a key/data pair expires after 30 minutes of
 inactivity.
 
 

--- a/README
+++ b/README
@@ -116,8 +116,8 @@ By default, a key/data pair can be up to 32 Mb large. This is a huge default.
 Start the server with that value and reduce it later according to the largest
 files you get in the work directory.
 
-Without the --expiration switch, a key/data pair expires after 30 minutes of
-inactivity.
+Without the --expiration switch, a key/data pair expires after 30 minutes since last modification.
+Fetching data does not extend the data lifetime.
 
 
     ------------------------ IMPLEMENTATION DESIGN ------------------------


### PR DESCRIPTION
The default expiration time is 30 minutes according to https://github.com/jedisct1/sharedance/blob/master/src/sharedanced.h#L263

The expiration time is counted since the data was modified last time.
https://github.com/jedisct1/sharedance/blob/master/src/expire.c#L27

The fetch action doesn’t extend the data lifetime. 
https://github.com/jedisct1/sharedance/blob/master/src/process.c#L211